### PR TITLE
refactor: Change Dotenv settings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,10 @@
-const env = Deno.env.toObject();
+import { config } from "https://deno.land/x/dotenv/mod.ts";
 
-export const APP_HOST = env.APP_HOST || "127.0.0.1";
-export const APP_PORT = env.APP_PORT || 3333;
+config({ export: true });
+
+const env = {
+  APP_HOST: Deno.env.get("APP_HOST") || "127.0.0.1",
+  APP_PORT: Deno.env.get("APP_PORT") || 3333,
+};
+
+export default env;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,5 @@
-import { config } from "https://deno.land/x/dotenv/mod.ts";
-import "https://deno.land/x/dotenv/load.ts";
 import { Application } from "https://deno.land/x/oak/mod.ts";
-
-config();
-
-import { APP_HOST, APP_PORT } from "./config.ts";
+import env from "./config.ts";
 import router from "./routing.ts";
 
 const app = new Application();
@@ -12,5 +7,5 @@ const app = new Application();
 app.use(router.routes());
 app.use(router.allowedMethods());
 
-console.log(`Listening on port ${APP_PORT}... 🧨`);
-await app.listen(`${APP_HOST}:${APP_PORT}`);
+console.log(`Listening on port ${env.APP_PORT}... 🧨`);
+await app.listen(`${env.APP_HOST}:${env.APP_PORT}`);


### PR DESCRIPTION
Changes Dotenv settings, making code simpler for future additions of environment variables.

The `export` option set to `true` exports all `.env` variables to the current process environment, allowing access via `Deno.env.get(<key>)`.

```javascript
config({ export: true });
```